### PR TITLE
Default hostname set to section name

### DIFF
--- a/iscdhcp/files/dhcpd.hosts
+++ b/iscdhcp/files/dhcpd.hosts
@@ -12,7 +12,7 @@
 host {{ h.name }} {
   hardware ethernet {{ h.mac }};
   fixed-address {{ h.ipaddr }};
-  ddns-hostname "{{ h.domain }}";
+  ddns-hostname "{{ h.domain|default(h.name) }}";
   {%- for a in h.additional|default([]) %}
   {{ a }};
   {%- endfor %}


### PR DESCRIPTION
Hello! I think, that it is good to use h.name as default value for hostname.
